### PR TITLE
Remove unused BUNDLE_ID input var

### DIFF
--- a/Cisco Spark/Cisco Spark.pkg.recipe
+++ b/Cisco Spark/Cisco Spark.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.chalcahuite.pkg.CiscoSpark</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>Cisco-Systems.Spark</string>
 		<key>NAME</key>
 		<string>CiscoSpark</string>
 	</dict>

--- a/Solstice/Solstice.pkg.recipe
+++ b/Solstice/Solstice.pkg.recipe
@@ -12,8 +12,6 @@
 	<dict>
 		<key>APP_FILENAME</key>
 		<string>SolsticeClientMacWeb</string>
-		<key>BUNDLE_ID</key>
-		<string>com.mersive.solstice.client</string>
 		<key>NAME</key>
 		<string>Solstice</string>
 	</dict>

--- a/Webex Teams/Webex Teams.pkg.recipe
+++ b/Webex Teams/Webex Teams.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.autopkg.chalcahuite-recipes.pkg.WebexTeams</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>Cisco-Systems.Spark</string>
 		<key>NAME</key>
 		<string>Webex Teams</string>
 	</dict>


### PR DESCRIPTION
This pull request removes unused instances of `BUNDLE_ID` from recipe input variables, which will help reduce confusion by new AutoPkg users and simplify overrides created from this point on.

Making `BUNDLE_ID` available as an input variable is a common practice in AutoPkg recipes that use the [PkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-PkgCreator) processor ([example](https://github.com/autopkg/homebysix-recipes/blob/4fec9244a3af0f9b7c8f61f35a5cd7f4622fb162/soma-zone/LaunchControl.pkg.recipe#L40-L41)). It's likely that these recipes transitioned from PkgCreator to the more streamlined [AppPkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-AppPkgCreator) processor some time ago, but the now-unused input variable for `BUNDLE_ID` was never removed.

Recipe run output is included below for all changed recipes (excluding jss and install recipe types). Any run failures are very likely to be unrelated to this change.

## ✅ Cisco Spark/Cisco Spark.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/chalcahuite-recipes/Cisco\ Spark/Cisco\ Spark.pkg.recipe
Processing repos/chalcahuite-recipes/Cisco Spark/Cisco Spark.pkg.recipe...
DeprecationWarning
{'Input': {'warning_message': 'This set of recipes has been deprecated and '
                              'will no longer be maintained. Please update '
                              'your recipe list and overrides to use the '
                              'version available from precursorca-recipes.'}}
DeprecationWarning: This set of recipes has been deprecated and will no longer be maintained. Please update your recipe list and overrides to use the version available from precursorca-recipes.
{'Output': {'deprecation_summary_result': {'data': {'name': 'Cisco Spark.pkg',
                                                    'warning': 'This set of '
                                                               'recipes has '
                                                               'been '
                                                               'deprecated and '
                                                               'will no longer '
                                                               'be maintained. '
                                                               'Please update '
                                                               'your recipe '
                                                               'list and '
                                                               'overrides to '
                                                               'use the '
                                                               'version '
                                                               'available from '
                                                               'precursorca-recipes.'},
                                           'report_fields': ['name', 'warning'],
                                           'summary_text': 'The following '
                                                           'recipes have '
                                                           'deprecation '
                                                           'warnings:'}}}
URLDownloader
{'Input': {'filename': 'CiscoSpark.dmg',
           'url': 'https://download.ciscospark.com/mac/CiscoSpark.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.chalcahuite.pkg.CiscoSpark/downloads/CiscoSpark.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.chalcahuite.pkg.CiscoSpark/downloads/CiscoSpark.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.chalcahuite.pkg.CiscoSpark/downloads/CiscoSpark.dmg/Cisco '
                         'Spark.app',
           'requirement': 'identifier "Cisco-Systems.Spark" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'DE8Y96K9QP'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.chalcahuite.pkg.CiscoSpark/downloads/CiscoSpark.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.pjmVqH/Cisco Spark.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.pjmVqH/Cisco Spark.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.pjmVqH/Cisco Spark.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.chalcahuite.pkg.CiscoSpark/downloads/CiscoSpark.dmg/Cisco '
                               'Spark.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.chalcahuite.pkg.CiscoSpark/downloads/CiscoSpark.dmg
Versioner: Found version 2.0.8481.0 in file /private/tmp/dmg.NtHbSq/Cisco Spark.app/Contents/Info.plist
{'Output': {'version': '2.0.8481.0'}}
AppPkgCreator
{'Input': {'version': '2.0.8481.0'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.chalcahuite.pkg.CiscoSpark/downloads/CiscoSpark.dmg
AppPkgCreator: Using path '/private/tmp/dmg.lWwneK/Cisco Spark.app' matched from globbed '/private/tmp/dmg.lWwneK/*.app'.
AppPkgCreator: BundleID: Cisco-Systems.Spark
AppPkgCreator: Copied /private/tmp/dmg.lWwneK/Cisco Spark.app to ~/Library/AutoPkg/Cache/com.github.chalcahuite.pkg.CiscoSpark/payload/Applications/Cisco Spark.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'Cisco-Systems.Spark',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.chalcahuite.pkg.CiscoSpark/Cisco '
                                                                    'Spark-2.0.8481.0.pkg',
                                                        'version': '2.0.8481.0'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '2.0.8481.0'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.chalcahuite.pkg.CiscoSpark/receipts/Cisco Spark.pkg-receipt-20210213-230038.plist

The following recipes have deprecation warnings:
    Name             Warning                                                                                                                                                                        
    ----             -------                                                                                                                                                                        
    Cisco Spark.pkg  This set of recipes has been deprecated and will no longer be maintained. Please update your recipe list and overrides to use the version available from precursorca-recipes.  

The following packages were built:
    Identifier           Version     Pkg Path                                                                                               
    ----------           -------     --------                                                                                               
    Cisco-Systems.Spark  2.0.8481.0  ~/Library/AutoPkg/Cache/com.github.chalcahuite.pkg.CiscoSpark/Cisco Spark-2.0.8481.0.pkg  
```

## ✅ Solstice/Solstice.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/chalcahuite-recipes/Solstice/Solstice.pkg.recipe
Processing repos/chalcahuite-recipes/Solstice/Solstice.pkg.recipe...
DeprecationWarning
{'Input': {'warning_message': 'This set of recipes has been deprecated and '
                              'will no longer be maintained. Please update '
                              'your recipe list and overrides to use the '
                              'version available from MLBZ521-recipes.'}}
DeprecationWarning: This set of recipes has been deprecated and will no longer be maintained. Please update your recipe list and overrides to use the version available from MLBZ521-recipes.
{'Output': {'deprecation_summary_result': {'data': {'name': 'Solstice.pkg',
                                                    'warning': 'This set of '
                                                               'recipes has '
                                                               'been '
                                                               'deprecated and '
                                                               'will no longer '
                                                               'be maintained. '
                                                               'Please update '
                                                               'your recipe '
                                                               'list and '
                                                               'overrides to '
                                                               'use the '
                                                               'version '
                                                               'available from '
                                                               'MLBZ521-recipes.'},
                                           'report_fields': ['name', 'warning'],
                                           'summary_text': 'The following '
                                                           'recipes have '
                                                           'deprecation '
                                                           'warnings:'}}}
URLDownloader
{'Input': {'filename': 'Solstice.zip',
           'url': 'https://www.mersive.com/downloads/SolsticeClientMacWeb.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.chalcahuite.pkg.Solstice/downloads/Solstice.zip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.chalcahuite.pkg.Solstice/downloads/Solstice.zip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/com.github.chalcahuite.pkg.Solstice/downloads/Solstice.zip',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.chalcahuite.pkg.Solstice/Solstice',
           'purge_destination': True}}
Unarchiver: Guessed archive format 'zip' from filename Solstice.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.chalcahuite.pkg.Solstice/downloads/Solstice.zip to ~/Library/AutoPkg/Cache/com.github.chalcahuite.pkg.Solstice/Solstice
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.chalcahuite.pkg.Solstice/Solstice/SolsticeClientMacWeb.app',
           'requirement': 'identifier "com.mersive.solstice.clientinstaller" '
                          'and anchor apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"63B5A5WDNG"'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.chalcahuite.pkg.Solstice/Solstice/SolsticeClientMacWeb.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.chalcahuite.pkg.Solstice/Solstice/SolsticeClientMacWeb.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.chalcahuite.pkg.Solstice/Solstice/SolsticeClientMacWeb.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.chalcahuite.pkg.Solstice/Solstice/SolsticeClientMacWeb.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: Found version 5.2.25530 in file ~/Library/AutoPkg/Cache/com.github.chalcahuite.pkg.Solstice/Solstice/SolsticeClientMacWeb.app/Contents/Info.plist
{'Output': {'version': '5.2.25530'}}
AppPkgCreator
{'Input': {'app_path': '~/Library/AutoPkg/Cache/com.github.chalcahuite.pkg.Solstice/Solstice/SolsticeClientMacWeb.app',
           'version': '5.2.25530'}}
AppPkgCreator: BundleID: com.mersive.solstice.clientinstaller
AppPkgCreator: Copied ~/Library/AutoPkg/Cache/com.github.chalcahuite.pkg.Solstice/Solstice/SolsticeClientMacWeb.app to ~/Library/AutoPkg/Cache/com.github.chalcahuite.pkg.Solstice/payload/Applications/SolsticeClientMacWeb.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.mersive.solstice.clientinstaller',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.chalcahuite.pkg.Solstice/SolsticeClientMacWeb-5.2.25530.pkg',
                                                        'version': '5.2.25530'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '5.2.25530'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.chalcahuite.pkg.Solstice/receipts/Solstice.pkg-receipt-20210213-230046.plist

The following recipes have deprecation warnings:
    Name          Warning                                                                                                                                                                    
    ----          -------                                                                                                                                                                    
    Solstice.pkg  This set of recipes has been deprecated and will no longer be maintained. Please update your recipe list and overrides to use the version available from MLBZ521-recipes.  

The following packages were built:
    Identifier                            Version    Pkg Path                                                                                                     
    ----------                            -------    --------                                                                                                     
    com.mersive.solstice.clientinstaller  5.2.25530  ~/Library/AutoPkg/Cache/com.github.chalcahuite.pkg.Solstice/SolsticeClientMacWeb-5.2.25530.pkg  
```

## ❌ Webex Teams/Webex Teams.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/chalcahuite-recipes/Webex\ Teams/Webex\ Teams.pkg.recipe
Processing repos/chalcahuite-recipes/Webex Teams/Webex Teams.pkg.recipe...
DeprecationWarning
{'Input': {'warning_message': 'This set of recipes has been deprecated and '
                              'will no longer be maintained. Please update '
                              'your recipe list and overrides to use the '
                              'version available from golbiga-recipes or '
                              'precursorca-recipes.'}}
DeprecationWarning: This set of recipes has been deprecated and will no longer be maintained. Please update your recipe list and overrides to use the version available from golbiga-recipes or precursorca-recipes.
{'Output': {'deprecation_summary_result': {'data': {'name': 'Webex Teams.pkg',
                                                    'warning': 'This set of '
                                                               'recipes has '
                                                               'been '
                                                               'deprecated and '
                                                               'will no longer '
                                                               'be maintained. '
                                                               'Please update '
                                                               'your recipe '
                                                               'list and '
                                                               'overrides to '
                                                               'use the '
                                                               'version '
                                                               'available from '
                                                               'golbiga-recipes '
                                                               'or '
                                                               'precursorca-recipes.'},
                                           'report_fields': ['name', 'warning'],
                                           'summary_text': 'The following '
                                                           'recipes have '
                                                           'deprecation '
                                                           'warnings:'}}}
URLDownloader
{'Input': {'filename': 'Webex Teams.dmg',
           'url': 'https://www.webex.com/downloads/WebexTeams.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.autopkg.chalcahuite-recipes.pkg.WebexTeams/downloads/Webex Teams.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.autopkg.chalcahuite-recipes.pkg.WebexTeams/downloads/Webex '
                        'Teams.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.autopkg.chalcahuite-recipes.pkg.WebexTeams/downloads/Webex '
                         'Teams.dmg/Webex Teams.app',
           'requirement': 'identifier "Cisco-Systems.Spark" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'DE8Y96K9QP'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.autopkg.chalcahuite-recipes.pkg.WebexTeams/downloads/Webex Teams.dmg
Receipt written to ~/Library/AutoPkg/Cache/com.github.autopkg.chalcahuite-recipes.pkg.WebexTeams/receipts/Webex Teams.pkg-receipt-20210213-230052.plist

The following recipes failed:
    repos/chalcahuite-recipes/Webex Teams/Webex Teams.pkg.recipe
        Error in com.github.autopkg.chalcahuite-recipes.pkg.WebexTeams: Processor: CodeSignatureVerifier: Error: Error processing path '/private/tmp/dmg.GctBxy/Webex Teams.app' with glob. 

The following recipes have deprecation warnings:
    Name             Warning                                                                                                                                                                                           
    ----             -------                                                                                                                                                                                           
    Webex Teams.pkg  This set of recipes has been deprecated and will no longer be maintained. Please update your recipe list and overrides to use the version available from golbiga-recipes or precursorca-recipes.  
```

