### PR TITLE
Fix and deprecate Password Monitor recipes

### DIFF
--- a/Password Monitor/Password Monitor.download.recipe
+++ b/Password Monitor/Password Monitor.download.recipe
@@ -12,25 +12,47 @@
 	<dict>
 		<key>NAME</key>
 		<string>Password Monitor</string>
-		<key>SPARKLE_FEED_URL</key>
-		<string>http://password-expiration-monitor.googlecode.com/files/pwdmon.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.5.0</string>
 	<key>Process</key>
 	<array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Google Password Monitor is no longer being developed. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>appcast_url</key>
-				<string>%SPARKLE_FEED_URL%</string>
+				<string>https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/password-expiration-monitor/pwdmon.xml</string>
 			</dict>
 			<key>Processor</key>
 			<string>SparkleUpdateInfoProvider</string>
 		</dict>
 		<dict>
+			<key>Processor</key>
+			<string>com.github.homebysix.FindAndReplace/FindAndReplace</string>
 			<key>Arguments</key>
 			<dict>
+				<key>input_string</key>
+				<string>%url%</string>
+				<key>find</key>
+				<string>://password-expiration-monitor.googlecode.com/files/</string>
+				<key>replace</key>
+				<string>://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/password-expiration-monitor/</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>url</key>
+				<string>%output_string%</string>
 				<key>filename</key>
 				<string>%NAME%-%version%.zip</string>
 			</dict>


### PR DESCRIPTION
This PR resolves issues with the download method in Password Monitor by using FindAndReplace to point the old URL to the new (archived) URL.

It's also apparent that no further versions of Password Monitor are forthcoming, so a deprecation warning has been added to the recipe.

```
% autopkg run -vvq 'Password Monitor/Password Monitor.download.recipe'
Processing Password Monitor/Password Monitor.download.recipe...
WARNING: Password Monitor/Password Monitor.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/password-expiration-monitor/pwdmon.xml'}}
SparkleUpdateInfoProvider: Items in feed: 1
SparkleUpdateInfoProvider: Items in default channel: 1
SparkleUpdateInfoProvider: Version retrieved from appcast: 1.1.54
SparkleUpdateInfoProvider: Found URL http://password-expiration-monitor.googlecode.com/files/PasswordMonitor154.zip
{'Output': {'url': 'http://password-expiration-monitor.googlecode.com/files/PasswordMonitor154.zip',
            'version': '1.1.54'}}
com.github.homebysix.FindAndReplace/FindAndReplace
{'Input': {'find': '://password-expiration-monitor.googlecode.com/files/',
           'input_string': 'http://password-expiration-monitor.googlecode.com/files/PasswordMonitor154.zip',
           'replace': '://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/password-expiration-monitor/'}}
FindAndReplace: Replacing "://password-expiration-monitor.googlecode.com/files/" with "://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/password-expiration-monitor/" in "http://password-expiration-monitor.googlecode.com/files/PasswordMonitor154.zip".
{'Output': {'output_string': 'http://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/password-expiration-monitor/PasswordMonitor154.zip'}}
URLDownloader
{'Input': {'filename': 'Password Monitor-1.1.54.zip',
           'url': 'http://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/password-expiration-monitor/PasswordMonitor154.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Sat, 23 Jan 2016 05:46:26 GMT
URLDownloader: Storing new ETag header: "3377891bc9f99efcdaa0fe3406e56093"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.chalcahuite.download.PasswordMonitor/downloads/Password Monitor-1.1.54.zip
{'Output': {'download_changed': True,
            'etag': '"3377891bc9f99efcdaa0fe3406e56093"',
            'last_modified': 'Sat, 23 Jan 2016 05:46:26 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.chalcahuite.download.PasswordMonitor/downloads/Password '
                        'Monitor-1.1.54.zip',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.chalcahuite.download.PasswordMonitor/downloads/Password '
                                                                        'Monitor-1.1.54.zip'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.chalcahuite.download.PasswordMonitor/receipts/Password Monitor.download-receipt-20241225-130550.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.chalcahuite.download.PasswordMonitor/downloads/Password Monitor-1.1.54.zip
```
